### PR TITLE
Updated length options

### DIFF
--- a/includes/conversion-options.php
+++ b/includes/conversion-options.php
@@ -26,7 +26,8 @@ $length_options = [
     'millimeters',
     'centimeters',
     'meters',
-    'kilometers'
+    'kilometers',
+    'nautical miles'
 ];
 
 $mass_options = [


### PR DESCRIPTION
Added nautical miles to the drop down menus. Functionality was built in but an essential element to the $length_options array was missing